### PR TITLE
fix: regeneration of severity highlighting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,11 +4,11 @@
 
 ## Fixes Issues
 
-- Closes #
-- Closes #
+- Closes
 
 ## Self Checklist
 
-- [ ] Added relevant comments, esp in complex areas
-- [ ] Updated docs (for bug fixes / features)
-- [ ] Created issues for follow-up changes or refactoring needed
+- [ ] Made sure that PR title has correct prefix (e.g. chore:, fix:, feat:, etc.)
+- [ ] The code is rebased on the latest main branch
+- [ ] Readme change log is clean
+- [ ] Commit messages are descriptive and contain the correct prefix

--- a/README.md
+++ b/README.md
@@ -69,66 +69,9 @@ Automated build and release of the extension
 
 ## 📦 Uncategorized
 
-- BUMP version to 0.1.17
-   - PR: #0
-
-
-
-### 0.1.18
-
-## 📦 Uncategorized
-
-- Merge support for HAR files
-   - PR: #0
-- add extra detection step
-   - PR: #0
-- BUMP version to 0.1.15
-   - PR: #0
-- Merge pull request #26 from felixSchober/har-file
-   - PR: #0
-- Bump typescript from 4.9.5 to 5.4.2
-   - PR: #0
-- do not skip on main push
-   - PR: #0
-- fix tagging issue
-   - PR: #0
-- update gitversion
-   - PR: #0
-- add PR template
-   - PR: #0
-- add workflow to auto assign the author of a PR
-   - PR: #0
-- use release drafter
-   - PR: #0
-- Feat: Repo organisation
-   - PR: #0
-- auto tag
-   - PR: #0
-- add template for feature request
-   - PR: #0
-- actions: Create auto labeller and templates
-   - PR: #0
-- Merge pull request #33 from felixSchober/dependabot/npm_and_yarn/typescript-5.4.2
-   - PR: #0
-- fix eslint issues in ui
-   - PR: #0
-- make sure timeout out messages are not blocking pending
-   - PR: #0
-- add to list of messages to reply to before executing actions
-   - PR: #0
-- specify node version
-   - PR: #0
-- BUMP version to 0.1.15
-   - PR: #0
-- build the change log
-   - PR: #0
-- fix next version
-   - PR: #0
-- BUMP version to 0.1.18
-   - PR: #0
-
-
+- Fix performance issues with large logs
+- Improve pipelines and generation of releases
 
 ### #{NEW_VERSION}#
 
-#{CHANGES}#
+### #{CHANGES}#

--- a/src/extension/src/textDecorations/KeywordHighlightDecorator.ts
+++ b/src/extension/src/textDecorations/KeywordHighlightDecorator.ts
@@ -69,6 +69,7 @@ export class KeywordHighlightDecorator implements vscode.Disposable {
             });
             // we have to wait for vscode to be ready before we can apply the decorations
             setTimeout(() => {
+                this.logger.info("onTextDocumentGenerationFinishedEvent.timeout");
                 void this.applyAllKeywordDecorations(newContent);
             }, 1000);
         });


### PR DESCRIPTION
## Describe Your Changes

Fix regeneration of severity and date decorations on content recalculation

*Smaller changes*:
- Make Text decorator methods private
- Add some log messages
- move logger initialization in Text Decorator
- remove the "newContent" parameter since it might be outdated

## Fixes Issues

- Closes #18 

## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [X] Updated docs (for bug fixes / features)
- [X] Created issues for follow-up changes or refactoring needed
