### PR TITLE
feat: Persist the log debugging state between logging sessions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -196,7 +196,7 @@ jobs:
           git config --local user.email ${{env.BUMP_AUTHOR_MAIL}}
           git config --local user.name ${{env.BUMP_AUTHOR_NAME}}
           git tag -a ${{ steps.gitversion.outputs.majorMinorPatch }} -f -m "Release ${{ steps.gitversion.outputs.majorMinorPatch }} through PR ${{ github.event.pull_request.number }}"
-          git push origin
+          git push origin -f --tags
 
       - name: create PR comment with new version
         uses: mshick/add-pr-comment@v2

--- a/README.md
+++ b/README.md
@@ -141,6 +141,27 @@ Automated build and release of the extension
 - BUMP version to 0.1.19
 
 
+### 0.2.0
+
+
+
+#### 📦 Uncategorized
+
+- Merge pull request #38 from felixSchober/fixes/fix-keyword-ack-messages
+- fix regeneration of severity highlighting
+- fix: update PR template
+- fix: cleanup readme
+- BUMP version to 0.1.18
+- bump gittools version
+- BUMP version to 0.1.18
+- fix GitVersion to use the right bumping logic
+- BUMP version to 0.1.18
+- checkout head.ref in bump version workflow job
+- BUMP version to 0.1.18
+- fix: supply branch name to gitversion
+- BUMP version to 0.1.19
+
+
 ### #{NEW_VERSION}#
 
 #{CHANGES}#

--- a/src/common/src/Events.ts
+++ b/src/common/src/Events.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 export const LogLevelSchema = z.union([z.literal("info"), z.literal("debug"), z.literal("warning"), z.literal("error")]);
 export type LogLevel = z.TypeOf<typeof LogLevelSchema>;
 
+export const ALL_LOG_LEVELS: LogLevel[] = ["info", "debug", "warning", "error"];
 /**
  * The event that is fired when the filter changes.
  */

--- a/src/common/src/postMessage/CommandId.ts
+++ b/src/common/src/postMessage/CommandId.ts
@@ -11,6 +11,7 @@ export const CommandIdSchema = z.union([
     z.literal("logMessage"),
     z.literal("logErrorMessage"),
     z.literal("filterCheckboxStateChange"),
+    z.literal("updateFilterCheckboxState"),
     z.literal("filterLogLevel"),
     z.literal("filterTime"),
     z.literal("filterSessionId"),
@@ -26,6 +27,7 @@ export const CommandIdSchema = z.union([
     z.literal("messageAck"),
     z.literal("setKeywordFiltersFromConfiguration"),
     z.literal("setKeywordHighlightsFromConfiguration"),
+    z.literal("updateKeywordHighlightConfiguration"),
     z.literal("webviewReady"),
 ]);
 

--- a/src/common/src/postMessage/CommandId.ts
+++ b/src/common/src/postMessage/CommandId.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 
 /**
  * The valid commands that can be sent between extension and webview.
+ * 
+ * After adding a new command, you must also add it to the `MessageSchemaMap` type in `src/common/src/postMessage/MessageSchemaMap.ts`.
  */
 export const CommandIdSchema = z.union([
     z.literal("logMessage"),
@@ -13,6 +15,7 @@ export const CommandIdSchema = z.union([
     z.literal("filterCheckboxStateChange"),
     z.literal("updateFilterCheckboxState"),
     z.literal("filterLogLevel"),
+    z.literal("setLogLevelFromConfiguration"),
     z.literal("filterTime"),
     z.literal("filterSessionId"),
     z.literal("filterNoEventTime"),
@@ -29,6 +32,9 @@ export const CommandIdSchema = z.union([
     z.literal("setKeywordHighlightsFromConfiguration"),
     z.literal("updateKeywordHighlightConfiguration"),
     z.literal("webviewReady"),
+    z.literal("noWorkspace"),
+    z.literal("selectWorkspaceFolder"),
+    z.literal("workspaceReady"),
 ]);
 
 

--- a/src/common/src/postMessage/MessageSchemaMap.ts
+++ b/src/common/src/postMessage/MessageSchemaMap.ts
@@ -85,6 +85,11 @@ export const MessageSchemaMap = {
          */
         isChecked: z.boolean(),
     }),
+    /**
+     * Message sent from the extension to the webview to set the log levels from the configuration with disabled (unchecked) state.
+     * E.g. ["info", "warning"] means that debug and error are enabled (checked) and info and warning are disabled (unchecked).
+     */
+    setLogLevelFromConfiguration: z.array(LogLevelSchema),
     filterTime: z.object({
         /**
          * The time filter.
@@ -221,7 +226,28 @@ export const MessageSchemaMap = {
         keywordDefinition: KeywordHighlightSchema,
 
     }),
+    /**
+     * Message sent from the webview to the extension to indicate that the webview is ready.
+     * After receiving this message, the extension can send messages to the webview.
+     */
     webviewReady: z.undefined(),
+
+    /**
+     * Message sent from the webview to the extension to indicate that there is no workspace folder.
+     */
+    noWorkspace: z.undefined(),
+
+    /**
+     * Message sent from the webview to the extension to select a workspace folder.
+     * Sent after the user has clicked the button to open logs.
+     * The data is the type of workspace folder to select.
+     */
+    selectWorkspaceFolder: z.union([z.literal("any"), z.literal("t21")]),
+
+    /**
+     * Message sent from the extension to the webview to indicate that the workspace is ready.
+     */
+    workspaceReady: z.undefined(),
 } as const;
 
 

--- a/src/common/src/postMessage/MessageSchemaMap.ts
+++ b/src/common/src/postMessage/MessageSchemaMap.ts
@@ -8,6 +8,9 @@ import { LogLevelSchema } from "../Events";
 import { SummaryInfoSchema } from "../model";
 import { KeywordHighlightSchema } from "../model/Keywords";
 
+
+const ConfigurationUpdateSchema = z.union([z.literal("add"), z.literal("remove"), z.literal("update")]);
+
 /**
  * Maps a command id to a schema for the data that is sent with the command.
  */
@@ -49,6 +52,27 @@ export const MessageSchemaMap = {
          * The state of the filter checkbox.
          */
         isChecked: z.boolean(),
+    }),
+    updateFilterCheckboxState: z.object({
+        /**
+         * The id of the filter checkbox.
+         */
+        id: z.string(),
+
+        /**
+         * The value of the filter checkbox.
+         */
+        value: z.string(),
+
+        /**
+         * The state of the filter checkbox.
+         */
+        isChecked: z.boolean(),
+
+        /**
+         * The type of update to perform.
+         */
+        updateType: ConfigurationUpdateSchema,
     }),
     filterLogLevel: z.object({
         /**
@@ -185,6 +209,18 @@ export const MessageSchemaMap = {
             isChecked: z.boolean(),
         })
     ),
+    updateKeywordHighlightConfiguration: z.object({
+        /**
+         * The type of update to perform.
+         */
+        updateType: ConfigurationUpdateSchema,
+
+        /**
+         * The keyword to highlight.
+         */
+        keywordDefinition: KeywordHighlightSchema,
+
+    }),
     webviewReady: z.undefined(),
 } as const;
 

--- a/src/common/src/service/PostMessageServiceBase.ts
+++ b/src/common/src/service/PostMessageServiceBase.ts
@@ -68,6 +68,10 @@ export abstract class PostMessageServiceBase implements IPostMessageService {
             commandSchema: MessageSchemaMap.filterCheckboxStateChange,
             eventListeners: [],
         },
+        updateFilterCheckboxState: {
+            commandSchema: MessageSchemaMap.updateFilterCheckboxState,
+            eventListeners: [],
+        },
         logErrorMessage: {
             commandSchema: MessageSchemaMap.logErrorMessage,
             eventListeners: [],
@@ -134,6 +138,10 @@ export abstract class PostMessageServiceBase implements IPostMessageService {
         },
         setKeywordHighlightsFromConfiguration: {
             commandSchema: MessageSchemaMap.setKeywordHighlightsFromConfiguration,
+            eventListeners: [],
+        },
+        updateKeywordHighlightConfiguration: {
+            commandSchema: MessageSchemaMap.updateKeywordHighlightConfiguration,
             eventListeners: [],
         },
         webviewReady: {

--- a/src/common/src/service/PostMessageServiceBase.ts
+++ b/src/common/src/service/PostMessageServiceBase.ts
@@ -100,6 +100,10 @@ export abstract class PostMessageServiceBase implements IPostMessageService {
             commandSchema: MessageSchemaMap.filterLogLevel,
             eventListeners: [],
         },
+        setLogLevelFromConfiguration: {
+            commandSchema: MessageSchemaMap.setLogLevelFromConfiguration,
+            eventListeners: [],
+        },
         filterNoEventTime: {
             commandSchema: MessageSchemaMap.filterNoEventTime,
             eventListeners: [],
@@ -146,6 +150,18 @@ export abstract class PostMessageServiceBase implements IPostMessageService {
         },
         webviewReady: {
             commandSchema: MessageSchemaMap.webviewReady,
+            eventListeners: [],
+        },
+        noWorkspace: {
+            commandSchema: MessageSchemaMap.noWorkspace,
+            eventListeners: [],
+        },
+        selectWorkspaceFolder: {
+            commandSchema: MessageSchemaMap.selectWorkspaceFolder,
+            eventListeners: [],
+        },
+        workspaceReady: {
+            commandSchema: MessageSchemaMap.workspaceReady,
             eventListeners: [],
         },
     };

--- a/src/extension/src/configuration/DocumentLocationManager.ts
+++ b/src/extension/src/configuration/DocumentLocationManager.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+import * as vscode from "vscode";
+
+import { LogContentProvider } from "../providers/LogContentProvider";
+import { ScopedILogger } from "../telemetry/ILogger";
+import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
+import { getEditor } from "../utils/getEditor";
+
+type RangeChangedEventData = {
+    /**
+     * The midpoint of the visible range. This is used to determine the line to scroll to when the user clicks on a log entry.
+     */
+    midpoint: number;
+};
+
+/**
+ * Manages the visible ranges of the active text editor and fires an event when the visible range changes.
+ */
+export class DocumentLocationManager implements vscode.Disposable {
+
+    private lastVisibleRanges: vscode.Range[] = [];
+
+    private rangeUpdateEvent: vscode.Disposable | null;
+
+    private readonly logger: ScopedILogger;
+
+    public onRangeChanged = new vscode.EventEmitter<RangeChangedEventData>();
+    
+    /**
+     * Creates a new instance of the DocumentLocationManager class.
+     * @param logger The logger to use for the class.
+     */
+    constructor(logger: ITelemetryLogger) {
+        this.logger = logger.createLoggerScope("DocumentLocationManager");
+        this.rangeUpdateEvent = vscode.window.onDidChangeTextEditorVisibleRanges(this.updateRanges, this);       
+    }
+
+    /**
+     * Disposes of the object.
+     */
+    dispose() {
+        this.logger.info("dispose");
+        if (this.rangeUpdateEvent) {
+            this.rangeUpdateEvent.dispose();
+            this.rangeUpdateEvent = null;
+        }
+    }
+
+    /**
+     * Updates the visible ranges of the active text editor by comparing the current visible ranges with the last visible ranges.
+     * @param e The text editor visible ranges change event.
+     */
+    private updateRanges(e: vscode.TextEditorVisibleRangesChangeEvent) {
+
+        // make sure we're only updating ranges for document created by the LogContentProvider
+        const expectedUri = LogContentProvider.documentUri;
+        if (e.textEditor.document.uri.path !== expectedUri.path) {
+            return;
+        }
+
+        const currentVisibleRanges = e.visibleRanges;
+        if (currentVisibleRanges.length === 0) {
+            return;
+        }
+
+        // compare the current visible ranges with the last visible ranges
+        if (this.lastVisibleRanges[0]?.start.line === currentVisibleRanges[0].start.line &&
+            this.lastVisibleRanges[0]?.end.line === currentVisibleRanges[0].end.line) {
+            return;
+        }
+
+        this.lastVisibleRanges = [...currentVisibleRanges];
+        const midpoint = Math.floor((currentVisibleRanges[0].start.line + currentVisibleRanges[0].end.line) / 2);
+        this.onRangeChanged.fire({ midpoint });
+    }
+
+    /**
+     * Sets the cursor to the specified midpoint.
+     * @param midpoint The midpoint of the visible range. This is used to determine the line to scroll to when the user clicks on a log entry.
+     */
+    public setCursor(midpoint: number) {
+        // find the correct editor 
+        const editor = getEditor();
+        if (editor) {
+            this.logger.info("setCursor", undefined, { midpoint: "" + midpoint });
+            
+            const position = new vscode.Position(midpoint, 0);
+            editor.selection = new vscode.Selection(position, position);
+        } else {
+            this.logger.info("setCursor.noEditorFound", undefined, { midpoint: "" + midpoint });
+        }
+    }
+}

--- a/src/extension/src/configuration/ProjectConfigurationManager.ts
+++ b/src/extension/src/configuration/ProjectConfigurationManager.ts
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+import * as path from "path";
+
+import { IPostMessageService } from "@t200logs/common";
+import { Uri, workspace } from "vscode";
+
+import { PostMessageDisposableService } from "../service/PostMessageDisposableService";
+import { WorkspaceService } from "../service/WorkspaceService";
+import { ScopedILogger } from "../telemetry/ILogger";
+import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
+
+import { DocumentLocationManager } from "./DocumentLocationManager";
+import {
+    ProjectConfiguration,
+    ProjectConfigurationSchemaVersion,
+    ValidProjectConfigurationVersion,
+    emptyProjectConfiguration,
+    getMostRecentConfiguration,
+} from "./ProjectConfigurationSchema";
+
+/**
+ * The name of the configuration file to use for the project.
+ */
+const CONFIGURATION_FILE_NAME = "t200logs.json";
+
+/**
+ * Class to store the current log state of the project inside the current workspace.
+ *
+ * When the user opens the project again, the state will be restored.
+ */
+export class ProjectConfigurationManager extends PostMessageDisposableService {
+    /**
+     * Logger instance for the class.
+     */
+    private readonly logger: ScopedILogger;
+
+    private _projectConfiguration: ProjectConfiguration | undefined;
+
+    /**
+     * Creates a new configuration manager.
+     * @param logger The logger to use for logging.
+     * @param workspaceService The workspace service to use for getting the workspace folder.
+     * @param documentLocationManager The document location manager to use for getting the current cursor position.
+     */
+    constructor(
+        logger: ITelemetryLogger,
+        private readonly workspaceService: WorkspaceService,
+        private readonly documentLocationManager: DocumentLocationManager
+    ) {
+        super();
+        this.logger = logger.createLoggerScope("ProjectConfigurationManager");
+
+        this.documentLocationManager.onRangeChanged.event(e => {
+            this.setConfigurationKey("cursorPosition", e.midpoint);
+        });
+    }
+
+    /**
+     * Sets up the listeners for the post message service.
+     * @param postMessageService The post message service to use for listening to configuration changes.
+     */
+    public addPostMessageService(postMessageService: IPostMessageService) {
+        this.logger.info("addPostMessageService");
+
+        // LOG LEVEL FILTER
+        const unregisterLogLevelChanged = postMessageService.registerMessageHandler("filterLogLevel", event => {
+            this.logger.info(`filterLogLevel.${event.logLevel}.changed`, `enabled: ${event.isChecked}`);
+
+            let disabledLogLevels = this.configuration.disabledLogLevels;
+
+            if (event.isChecked && disabledLogLevels.includes(event.logLevel)) {
+                disabledLogLevels = disabledLogLevels.filter(level => level !== event.logLevel);
+            }
+            if (!event.isChecked && !disabledLogLevels.includes(event.logLevel)) {
+                disabledLogLevels.push(event.logLevel);
+            }
+            this.setConfigurationKey("disabledLogLevels", disabledLogLevels);
+        });
+        this.unregisterListeners.push(unregisterLogLevelChanged);
+
+        // KEYWORD FILTER
+        const unregisterKeywordFilterChanged = postMessageService.registerMessageHandler("updateFilterCheckboxState", data => {
+            this.logger.info("updateFilterCheckboxState", `filter ${data.updateType} -> ${data.value}`, { event: JSON.stringify(data) });
+            const currentFilters = this.configuration.enabledKeywordFilters;
+
+            // check if the keyword is already present in the list
+            const index = currentFilters.findIndex(kw => kw === data.value);
+            switch (data.updateType) {
+                case "add":
+                    if (index === -1) {
+                        currentFilters.push(data.value);
+                    } else {
+                        this.logger.logException("updateFilterCheckboxState.add", new Error(`Keyword ${data.value} already exists`));
+                    }
+                    break;
+                case "remove":
+                    if (index !== -1) {
+                        currentFilters.splice(index, 1);
+                    } else {
+                        this.logger.logException("updateFilterCheckboxState.remove", new Error(`Keyword ${data.value} does not exist`));
+                    }
+                    break;
+                case "update":
+                    // found a keyword and it was disabled -> remove it
+                    if (index !== -1) {
+                        currentFilters.splice(index, 1);
+                        this.logger.info("updateFilterCheckboxState.update", `filter ${data.value} removed`, {
+                            event: JSON.stringify(data),
+                        });
+                    }
+
+                    // found a keyword and it was enabled -> add it
+                    if (index === -1) {
+                        currentFilters.push(data.value);
+                        this.logger.info("updateFilterCheckboxState.update", `filter ${data.value} added`, { event: JSON.stringify(data) });
+                    }
+            }
+
+            this.setConfigurationKey("enabledKeywordFilters", currentFilters);
+        });
+        this.unregisterListeners.push(unregisterKeywordFilterChanged);
+
+        // TIME FILTER (set by the user in the webview panel)
+        const unregisterTimeFilterChanged = postMessageService.registerMessageHandler("filterTime", data => {
+            this.logger.info("filterTime", `from ${data.fromDate?.toString()} to ${data.tillDate?.toString()}`, {
+                event: JSON.stringify(data),
+            });
+            this.setConfigurationKey("enabledTimeFilters", data);
+        });
+        this.unregisterListeners.push(unregisterTimeFilterChanged);
+
+        // TIME FILTER (set by the log content provider)
+        const unregisterTimeFilterChangedEvent = postMessageService.registerMessageHandler("updateTimeFilters", data => {
+            this.logger.info("updateTimeFilters", `from ${data.fromDate?.toString()} to ${data.tillDate?.toString()}`, {
+                event: JSON.stringify(data),
+            });
+            this.setConfigurationKey("enabledTimeFilters", data);
+        });
+        this.unregisterListeners.push(unregisterTimeFilterChangedEvent);
+
+        // KEYWORD HIGHLIGHTS
+        const unregisterHighlightChanged = postMessageService.registerMessageHandler("updateKeywordHighlightConfiguration", data => {
+            this.logger.info("updateKeywordHighlightConfiguration", undefined, { event: JSON.stringify(data) });
+            const currentHighlights = this.configuration.enabledKeywordHighlights;
+
+            // check if the keyword is already present in the list
+            const index = currentHighlights.findIndex(kw => kw.keyword === data.keywordDefinition.keyword);
+
+            switch (data.updateType) {
+                case "add":
+                    if (index === -1) {
+                        currentHighlights.push(data.keywordDefinition);
+                    } else {
+                        this.logger.logException(
+                            "updateKeywordHighlightConfiguration.add",
+                            new Error(`Keyword ${data.keywordDefinition.keyword} already exists`)
+                        );
+                    }
+                    break;
+                case "remove":
+                    if (index !== -1) {
+                        currentHighlights.splice(index, 1);
+                    } else {
+                        this.logger.logException(
+                            "updateKeywordHighlightConfiguration.remove",
+                            new Error(`Keyword ${data.keywordDefinition.keyword} does not exist`)
+                        );
+                    }
+                    break;
+                case "update":
+                    if (index !== -1) {
+                        currentHighlights[index] = data.keywordDefinition;
+                    } else {
+                        // the keyword does not exist, so we add it (it was probably enabled by checking the checkbox in the webview panel)
+                        currentHighlights.push(data.keywordDefinition);
+                    }
+                    break;
+            }
+
+            this.setConfigurationKey("enabledKeywordHighlights", currentHighlights);
+        });
+        this.unregisterListeners.push(unregisterHighlightChanged);
+        this.logger.info("addPostMessageService.success", undefined, { listeners: "" + this.unregisterListeners.length });
+    }
+
+    /**
+     * The current project configuration.
+     * @returns The current project configuration.
+     */
+    public get configuration(): ProjectConfiguration {
+        return this._projectConfiguration || emptyProjectConfiguration;
+    }
+
+    /**
+     * Sets the current project configuration.
+     * @param value The new project configuration.
+     */
+    public set configuration(value: ProjectConfiguration | undefined) {
+        this._projectConfiguration = value;
+        void this.saveConfiguration();
+    }
+
+    /**
+     * Sets a single configuration key to a new value.
+     * @param key The key of the configuration to set.
+     * @param value The value to set for the configuration key.
+     */
+    public setConfigurationKey<T extends keyof ProjectConfiguration>(key: T, value: ProjectConfiguration[T]) {
+        if (!this._projectConfiguration) {
+            this._projectConfiguration = emptyProjectConfiguration;
+        }
+        this._projectConfiguration[key] = value;
+        void this.saveConfiguration();
+    }
+
+    /**
+     * Loads the current project configuration from the configuration file.
+     */
+    public async initialize() {
+        this.logger.info("initialize");
+        const configurationFilePath = this.configurationFilePath;
+
+        if (!configurationFilePath) {
+            this.logger.info("initialize.noConfigurationFile");
+            return;
+        }
+
+        
+
+        // try opening the file - failing is expected if the file does not exist
+        // In that case, we'll just create a new configuration file.
+        let fileContent: string | undefined;
+        try {
+            const file = await workspace.fs.readFile(Uri.file(configurationFilePath));
+            fileContent = file.toString();
+        } catch (error) {
+            this.logger.logException("initialize.fileError", error);
+        }
+
+        // if the file does not exist, create a new one
+        if (!fileContent) {
+            this.logger.info("initialize.createConfigurationFile");
+            this._projectConfiguration = undefined;
+            await this.saveConfiguration();
+            return;
+        }
+        this.logger.info("initialize.fileContent", undefined, { content: fileContent });
+
+        // parse the file content from a string to JSON and finally verify it against the schema
+        let jsonContent: unknown;
+        try {
+            jsonContent = JSON.parse(fileContent);
+            this.logger.info("initialize.parsed");
+        } catch (parseError) {
+            this.logger.logException(
+                "initialize.parseError",
+                parseError,
+                "Failed to parse the local project configuration file.",
+                {},
+                true,
+                "Configuration Error"
+            );
+            return;
+        }
+
+        const fileVersion = this.getConfigurationSchemaVersion(jsonContent);
+        if (!fileVersion) {
+            this._projectConfiguration = undefined;
+            await this.saveConfiguration();
+            return;
+        }
+        this.logger.info("initialize.version", undefined, { version: fileVersion });
+
+        try {
+            const [mostRecentConfiguration, wasMigrated] = getMostRecentConfiguration(fileVersion, jsonContent);
+            this._projectConfiguration = mostRecentConfiguration;
+
+            if (wasMigrated) {
+                this.logger.info("initialize.migrated", undefined, { version: fileVersion });
+                await this.saveConfiguration();
+            }
+        } catch (error) {
+            this.logger.logException(
+                "initialize.parseError",
+                error,
+                `Failed to parse the local project configuration file. You might have to delete the file and restart the extension. Error ${error?.toString?.()}`,
+                {},
+                true,
+                "Configuration Error"
+            );
+            return;
+        }
+
+        this.logger.info("initialize.success", undefined, { configuration: JSON.stringify(this._projectConfiguration) });
+    }
+
+    /**
+     * Saves the current project configuration to the configuration file.
+     * If no configuration exists, a new one will be created.
+     */
+    public async saveConfiguration() {
+        this.logger.info("saveConfiguration", undefined, { isDefined: `${!!this._projectConfiguration}` });
+        let configuration: ProjectConfiguration | undefined = this._projectConfiguration;
+        if (!configuration) {
+            configuration = emptyProjectConfiguration;
+            this._projectConfiguration = configuration;
+        }
+
+        let filePath = this.configurationFilePath;
+        if (!filePath) {
+            this.logger.info("saveConfiguration.noWorkspace");
+            return;
+        }
+
+        // write the file
+        const fileContent = JSON.stringify(configuration, null, 4);
+        await workspace.fs.writeFile(Uri.file(filePath), Buffer.from(fileContent));
+        this.logger.info("saveConfiguration.success");
+    }
+
+    /**
+     * Extracts the version of the project configuration file.
+     * @param jsonContent The `unknown` JSON content to verify.
+     * @returns The version of the project configuration file or `undefined` if the version could not be verified.
+     */
+    private getConfigurationSchemaVersion(jsonContent: unknown): ValidProjectConfigurationVersion | undefined {
+        const parseResults = ProjectConfigurationSchemaVersion.safeParse(jsonContent);
+        if (parseResults.success) {
+            return parseResults.data.version;
+        }
+
+        this.logger.logException(
+            "getConfigurationSchemaVersion",
+            new Error("Could not verify the project configuration file version."),
+            `Failed to verify the local project configuration file version. Please delete the file and try again. Error ${parseResults.error.toString()}`,
+            {},
+            true,
+            "Configuration Error"
+        );
+        return undefined;
+    }
+
+    /**
+     * The path to the configuration file.
+     * @returns The path to the configuration file or `undefined` if no workspace is open.
+     */
+    private get configurationFilePath(): string | undefined {
+        if (!this.workspaceService.hasWorkspace) {
+            this.logger.info("configurationFilePath.noWorkspace");
+            return undefined;
+        }
+        return path.join(this.workspaceService.folder?.uri?.fsPath || "", CONFIGURATION_FILE_NAME);
+    }
+}
+

--- a/src/extension/src/configuration/ProjectConfigurationSchema.ts
+++ b/src/extension/src/configuration/ProjectConfigurationSchema.ts
@@ -137,7 +137,6 @@ export const emptyProjectConfiguration: ProjectConfiguration = {
  * @returns The new version of the project configuration.
  */
 const upgradeFrom100 = (old: z.infer<typeof ProjectConfigurationSchema100>): ProjectConfiguration => {
-    debugger;
     const disabledLogLevels = ALL_LOG_LEVELS.filter(l => !old.enabledLogLevels.includes(l));
     return {
         ...old,

--- a/src/extension/src/configuration/ProjectConfigurationSchema.ts
+++ b/src/extension/src/configuration/ProjectConfigurationSchema.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+import { ALL_LOG_LEVELS, KeywordHighlightSchema, LogLevelSchema, MessageSchemaMap } from "@t200logs/common";
+import { z } from "zod";
+
+/**
+ * The valid versions of the project configuration schema.
+ */
+const ValidVersionSchema = z.union([z.literal("1.0.0"), z.literal("1.0.1")]);
+
+/**
+ * The valid versions that a project configuration can be.
+ */
+export type ValidProjectConfigurationVersion = z.TypeOf<typeof ValidVersionSchema>;
+
+/**
+ * This is the sub part of a project configuration that just contains the version number.
+ * This can be used to extract just the version number from a project configuration so that the right schema can be used to validate the rest of the configuration.
+ */
+export const ProjectConfigurationSchemaVersion = z.object({
+    /**
+     * The version of the configuration schema.
+     */
+    version: ValidVersionSchema,
+});
+
+/**
+ * DUMMY 1.0.0 schema. This is a placeholder for the actual schema.
+ */
+const ProjectConfigurationSchema100 = z.object({
+    /**
+     * The version of the configuration schema.
+     */
+    version: z.literal("1.0.0"),
+
+    /**
+     * The current cursor position in the log file.
+     */
+    cursorPosition: z.number(),
+
+    /**
+     * The log levels that are enabled.
+     */
+    enabledLogLevels: z.array(LogLevelSchema),
+
+    /**
+     * The keyword filters that are enabled for the project.
+     */
+    enabledKeywordFilters: z.array(z.string()),
+
+    /**
+     * The time filters that are enabled for the project.
+     */
+    enabledTimeFilters: MessageSchemaMap.filterTime,
+
+    /**
+     * The keyword highlights that are enabled for the project.
+     */
+    enabledKeywordHighlights: z.array(KeywordHighlightSchema),
+});;
+
+/**
+ * The current schema for the project configuration stored within the workspace as a json file.
+ */
+const ProjectConfigurationSchema = z.object({
+    /**
+     * The version of the configuration schema.
+     */
+    version: z.literal("1.0.1"),
+
+    /**
+     * The current cursor position in the log file.
+     */
+    cursorPosition: z.number(),
+
+    /**
+     * The log levels that are disabled.
+     */
+    disabledLogLevels: z.array(LogLevelSchema),
+
+    /**
+     * The keyword filters that are enabled for the project.
+     */
+    enabledKeywordFilters: z.array(z.string()),
+
+    /**
+     * The time filters that are enabled for the project.
+     */
+    enabledTimeFilters: MessageSchemaMap.filterTime,
+
+    /**
+     * The keyword highlights that are enabled for the project.
+     */
+    enabledKeywordHighlights: z.array(KeywordHighlightSchema),
+});
+
+/**
+ * Iterates over all the schema versions and creates a map of the schema version to the schema.
+ */
+type AllSchemas = {[version in ValidProjectConfigurationVersion]: z.Schema};
+
+/**
+ * The map of all the project configuration schemas.
+ */
+export const ProjectConfigurationSchemas: AllSchemas = {
+    "1.0.0": ProjectConfigurationSchema100,
+    "1.0.1": ProjectConfigurationSchema,
+};
+/**
+ * The current schema for the project configuration stored within the workspace as a json file.
+ * When a new version of the schema is added, the version number should be updated and a new schema should be added to the `ProjectConfigurationSchemas` object.
+ */
+const CurrentProjectConfigurationSchema = ProjectConfigurationSchema;
+
+/**
+ * The type representing the current {@link ProjectConfigurationSchema}.
+ */
+export type ProjectConfiguration = z.TypeOf<typeof CurrentProjectConfigurationSchema>;
+
+export const emptyProjectConfiguration: ProjectConfiguration = {
+    version: "1.0.1",
+        cursorPosition: 0,
+        disabledLogLevels: [],
+        enabledKeywordFilters: [],
+        enabledTimeFilters: {
+            fromDate: null,
+            tillDate: null,
+        },
+        enabledKeywordHighlights: [],
+    };
+
+/**
+ * Dummy upgrades from 1.0.0 to the latest version.
+ * @param old The old version of the project configuration.
+ * @returns The new version of the project configuration.
+ */
+const upgradeFrom100 = (old: z.infer<typeof ProjectConfigurationSchema100>): ProjectConfiguration => {
+    debugger;
+    const disabledLogLevels = ALL_LOG_LEVELS.filter(l => !old.enabledLogLevels.includes(l));
+    return {
+        ...old,
+        version: "1.0.1",
+        disabledLogLevels
+    };
+};
+
+/**
+ * Gets the most recent version of the project configuration.
+ * 
+ * In case the version is not the most recent, the configuration will be upgraded to the most recent version.
+ * This function will throw an error if parsing is not possible.
+ * @param oldVersion The old version of the project configuration.
+ * @param jsonContent The content of the project configuration file.
+ * @returns Returns a tuple of the most recent project configuration and a boolean indicating if the configuration was upgraded.
+ */
+export const getMostRecentConfiguration = (oldVersion: ValidProjectConfigurationVersion, jsonContent: unknown): [ProjectConfiguration, boolean] => {
+    const OldVersionSchema = ProjectConfigurationSchemas[oldVersion];
+    switch (oldVersion) {
+        case "1.0.0":
+            return [upgradeFrom100(OldVersionSchema.parse(jsonContent)), true];
+        default:
+            return [CurrentProjectConfigurationSchema.parse(jsonContent), false];
+    }
+};

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -36,7 +36,6 @@ export async function activate(context: vscode.ExtensionContext) {
     const configurationManager = new ConfigurationManager(telemetryReporter);
     telemetryReporter.startLogging(configurationManager.shouldShowWelcomeMessage);
 
-    setupFoldingRangeProvider(context);
 
     if (!logContentProvider || !postMessageService || !onCodeLensFilterApplied) {
         await telemetryReporter.info("extension.activate().serviceInitialization");
@@ -49,10 +48,15 @@ export async function activate(context: vscode.ExtensionContext) {
             telemetryReporter
         );
 
+        configurationManager.addPostMessageService(postMessageService);
+
         disposableServices.push(onCodeLensFilterApplied);
         disposableServices.push(postMessageService);
         disposableServices.push(logContentProvider);
+        disposableServices.push(configurationManager);
     }
+
+    setupFoldingRangeProvider(context);
 
     context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(LogContentProvider.documentScheme, logContentProvider));
 

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -5,7 +5,6 @@
 import type { FilterChangedEvent, TimeFilterChangedEvent } from "@t200logs/common";
 import * as vscode from "vscode";
 
-import { ExtensionPostMessageService } from "./ExtensionPostMessageService";
 import { ConfigurationManager } from "./configuration/ConfigurationManager";
 import { EXTENSION_ID } from "./constants/constants";
 import { SummaryInfoProvider } from "./info/SummaryInfoProvider";
@@ -13,6 +12,7 @@ import { DateRange, FilterTimeRangeLensProvider } from "./providers/FilterTimeRa
 import { LogContentProvider } from "./providers/LogContentProvider";
 import { LogFoldingRangeProvider } from "./providers/LogFoldingRangeProvider";
 import { WebviewPanelProvider } from "./providers/WebviewPanelProvider";
+import { ExtensionPostMessageService } from "./service/ExtensionPostMessageService";
 import { DevLogger } from "./telemetry";
 import { ITelemetryLogger } from "./telemetry/ITelemetryLogger";
 import { KeywordHighlightDecorator } from "./textDecorations/KeywordHighlightDecorator";

--- a/src/extension/src/info/SummaryInfoProvider.ts
+++ b/src/extension/src/info/SummaryInfoProvider.ts
@@ -8,6 +8,7 @@ import { IPostMessageService, PostMessageEventRespondFunction, SummaryInfo, Summ
 import * as vscode from "vscode";
 
 import { GUID_REGEX } from "../constants/regex";
+import { PostMessageDisposableService } from "../service/PostMessageDisposableService";
 import { ScopedILogger } from "../telemetry/ILogger";
 import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
 
@@ -50,13 +51,8 @@ const userRegex = /(\S+@\S+)\s+(\S+)\s+(\S+)\s+TId:([0-9a-f-]+)\s+OId:([0-9a-f-]
 /**
  * SummaryInfoProvider is a class that provides the ability to get summary information from teh summary.txt file.
  */
-export class SummaryInfoProvider implements vscode.Disposable {
+export class SummaryInfoProvider extends PostMessageDisposableService {
     private readonly logger: ScopedILogger;
-
-    /**
-     * The handler registration.
-     */
-    private readonly unregisterHandler: () => void;
 
     /**
      * Initializes a new instance of the SummaryInfoProvider class.
@@ -64,17 +60,13 @@ export class SummaryInfoProvider implements vscode.Disposable {
      * @param logger The logger.
      */
     constructor(postMessageService: IPostMessageService, logger: ITelemetryLogger) {
+        super();
         this.logger = logger.createLoggerScope("SummaryInfoProvider");
 
-        this.unregisterHandler = postMessageService.registerMessageHandler("getSummary", (_, respond) => {
+        const unregisterSummaryListener = postMessageService.registerMessageHandler("getSummary", (_, respond) => {
             void this.handleGetSummaryRequest(respond);
         });
-    }
-    /**
-     * Disposes the summary info provider.
-     */
-    dispose() {
-        this.unregisterHandler();
+        this.unregisterListeners.push(unregisterSummaryListener);
     }
 
     /**

--- a/src/extension/src/providers/HarFileProvider.ts
+++ b/src/extension/src/providers/HarFileProvider.ts
@@ -5,7 +5,7 @@
 import * as fs from "fs/promises";
 
 import { HarEntry, HarSchema, JwtSchema } from "@t200logs/common";
-import { CancellationToken, Disposable, Uri, workspace } from "vscode";
+import { CancellationToken, Uri, workspace } from "vscode";
 
 import { ScopedILogger } from "../telemetry/ILogger";
 import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
@@ -15,13 +15,8 @@ import { LogEntry } from "./LogEntry";
 /**
  *
  */
-export class HarFileProvider implements Disposable {
+export class HarFileProvider {
     private readonly logger: ScopedILogger;
-
-    /**
-     * List of post message handler registrations that need to be cleaned up when the provider is disposed.
-     */
-    private readonly handlerRegistrations: Array<() => void> = [];
 
     /**
      * Cache of all converted, unsorted HAR file entries.
@@ -252,15 +247,6 @@ export class HarFileProvider implements Disposable {
 
         result += "] ";
         return result;
-    }
-
-    /**
-     * Disposes all child disposables of the service.
-     */
-    dispose() {
-        for (const unregister of this.handlerRegistrations) {
-            unregister();
-        }
     }
 }
 

--- a/src/extension/src/providers/LogFoldingRangeProvider.ts
+++ b/src/extension/src/providers/LogFoldingRangeProvider.ts
@@ -14,6 +14,7 @@ import {
 import { WEB_DATE_REGEX } from "../constants/regex";
 import { ScopedILogger } from "../telemetry/ILogger";
 import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
+import { getEditor } from "../utils/getEditor";
 
 import { LogContentProvider } from "./LogContentProvider";
 
@@ -67,7 +68,7 @@ export class LogFoldingRangeProvider implements FoldingRangeProvider {
         this.logger.info("provideFoldingRanges.end", undefined, { foldingRangesCount: "" + foldingRanges.length });
 
         // Set the decorations
-        const activeEditor = vscodeWindow.activeTextEditor;
+        const activeEditor = getEditor();
         if (activeEditor) {
             activeEditor.setDecorations(this.decorationType, decorations);
         } else {

--- a/src/extension/src/providers/WebviewPanelProvider.ts
+++ b/src/extension/src/providers/WebviewPanelProvider.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 
 import { CancellationToken, Uri as VscodeUri, Webview, WebviewView, WebviewViewProvider, WebviewViewResolveContext } from "vscode";
 
-import { ExtensionPostMessageService } from "../ExtensionPostMessageService";
+import { ExtensionPostMessageService } from "../service/ExtensionPostMessageService";
 import { ScopedILogger } from "../telemetry/ILogger";
 import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
 import { throwIfCancellation } from "../utils/throwIfCancellation";

--- a/src/extension/src/service/ExtensionPostMessageService.ts
+++ b/src/extension/src/service/ExtensionPostMessageService.ts
@@ -5,8 +5,8 @@
 import { PostMessageServiceBase } from "@t200logs/common";
 import { Disposable, Webview } from "vscode";
 
-import { ScopedILogger } from "./telemetry/ILogger";
-import { ITelemetryLogger } from "./telemetry/ITelemetryLogger";
+import { ScopedILogger } from "../telemetry/ILogger";
+import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
 
 /**
  * The post message service for the extension.

--- a/src/extension/src/service/PostMessageDisposableService.ts
+++ b/src/extension/src/service/PostMessageDisposableService.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+import { Disposable } from "vscode";
+
+/**
+ * Abstract class for services that listen to post messages and need to unregister the listeners when disposed.
+ */
+export abstract class PostMessageDisposableService implements Disposable {
+    
+
+    /**
+     * List of functions which will unregister the listeners.
+     */
+    protected readonly unregisterListeners: (() => void)[] = [];
+
+
+    /**
+     * Disposes of the object by unregistering all listeners.
+     */
+    dispose() {
+         // pop all the handler registrations
+         while (this.unregisterListeners.length > 0) {
+            const handler = this.unregisterListeners.pop();
+            if (handler) {
+                handler();
+            }
+        }
+    }
+}

--- a/src/extension/src/service/WorkspaceService.ts
+++ b/src/extension/src/service/WorkspaceService.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+import { IPostMessageService, PostMessageEventRespondFunction } from "@t200logs/common";
+import { WorkspaceFolder, window, workspace } from "vscode";
+
+import { ScopedILogger } from "../telemetry/ILogger";
+import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
+
+import { PostMessageDisposableService } from "./PostMessageDisposableService";
+
+/**
+ * Class which manages the state of the currently opened workspace folder.
+ */
+export class WorkspaceService extends PostMessageDisposableService {
+
+    /**
+     * The currently selected workspace folder.
+     */
+    private _workspaceFolder: WorkspaceFolder | undefined;
+
+    /**
+     * Logger instance for the class.
+     */
+    private readonly logger: ScopedILogger;
+
+    /**
+     * Creates a new workspace service.
+     * @param logger The logger to use for logging.
+     */
+    constructor(logger: ITelemetryLogger) {
+        super();
+        this.logger = logger.createLoggerScope("WorkspaceService");        
+        this.initializeFolder();
+    }
+
+    /**
+     * Flag indicating if the workspace is ready.
+     * @returns True if the workspace is ready, false otherwise.
+     */
+    public get hasWorkspace(): boolean {
+        return !!this._workspaceFolder;
+    }
+
+    /**
+     * The currently selected workspace folder.
+     * This might be `undefined` if no workspace folder is selected.
+     * @returns The currently selected workspace folder.
+     */
+    public get folder(): WorkspaceFolder | undefined {
+        return this._workspaceFolder;
+    }
+
+    /**
+     * Initializes the workspace service by trying to find the first workspace folder.
+     */
+    private initializeFolder(): void {
+        this.logger.info("initialize");
+        const folders = workspace.workspaceFolders;
+        if (folders && folders.length > 0) {
+            this.logger.info("initialize.found", undefined, { folderCount: "" + folders.length, selectedFolder: folders[0].uri.fsPath, allFolders: folders.map(f => f.uri.fsPath).join(",")});
+            this._workspaceFolder = folders[0];
+            return;
+        }
+
+        this.logger.info("initialize.notFound");
+    }
+
+    /**
+     * Adds a post message service to the workspace service.
+     * @param postMessageService The post message service to use for sending messages to the webview.
+     */
+    public addPostMessageService(postMessageService: IPostMessageService) {
+        this.logger.info("addPostMessageService");
+        this.setupListeners(postMessageService);
+
+        if (this.hasWorkspace) {
+            postMessageService.sendAndForget({command: "workspaceReady", data: undefined});
+        } else {
+            postMessageService.sendAndForget({command: "noWorkspace", data: undefined});
+        }
+    }
+
+    /**
+     * Sets up the listeners for the post message service.
+     * We listen for the selectWorkspaceFolder message to let the user choose a workspace folder.
+     * @param postMessageService The post message service to use for listening to configuration changes.
+     */
+    private setupListeners(postMessageService: IPostMessageService) {
+        this.logger.info("setupListeners");
+
+        const unregisterWorkspaceSelectionListener = postMessageService.registerMessageHandler(
+            "selectWorkspaceFolder",
+            (eventType, respond) => this.handleSelectWorkspaceFolder(postMessageService, eventType, respond)
+        );
+        this.unregisterListeners.push(unregisterWorkspaceSelectionListener);
+    }
+
+    /**
+     * Handles the selectWorkspaceFolder message event.
+     * @param postMessageService The post message service to use for sending messages to the webview.
+     * @param eventType The type of workspace folder to select.
+     * @param respond The function to call to respond and acknowledge the message.
+     */
+    private handleSelectWorkspaceFolder(postMessageService: IPostMessageService, eventType: "any" | "t21", respond: PostMessageEventRespondFunction) {
+        switch (eventType) {
+            case "any":
+                void this.chooseAnyWorkspaceFolder(postMessageService);
+                break;
+            case "t21":
+                this.selectT21WorkspaceFolder(postMessageService);
+                break;
+        }
+        respond({command: "messageAck", data: undefined});
+    }
+
+    /**
+     * Tries to select the Teams logs workspace folder.
+     * @param postMessageService The post message service to use for sending messages to the webview.
+     */
+    private selectT21WorkspaceFolder(postMessageService: IPostMessageService): void {
+        // TODO: Implement this method.
+        postMessageService.sendAndForget({command: "noWorkspace", data: undefined});
+    }
+
+    /**
+     * Opens a dialog to let the user choose a workspace folder.
+     * If the user cancels the dialog, a message is sent to the webview to indicate that no workspace folder was selected.
+     * @param postMessageService The post message service to use for sending messages to the webview.
+     * @returns Void.
+     */
+    private async chooseAnyWorkspaceFolder(postMessageService: IPostMessageService): Promise<void> {
+        this.logger.info("chooseWorkspaceFolder");
+
+        const folders = await window.showOpenDialog({
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: "Select",
+            title: "Select the Teams logs"
+        });
+
+        if (!folders) {
+            this.logger.info("chooseWorkspaceFolder.cancelled");
+            postMessageService.sendAndForget({command: "noWorkspace", data: undefined});
+            return undefined;
+        }
+
+        const folder = folders[0];
+        this._workspaceFolder = workspace.getWorkspaceFolder(folder);
+        this.logger.info("chooseWorkspaceFolder.selected", undefined, { folder: folder.fsPath });
+        postMessageService.sendAndForget({command: "workspaceReady", data: undefined});
+    } 
+}

--- a/src/extension/src/textDecorations/KeywordHighlightDecorator.ts
+++ b/src/extension/src/textDecorations/KeywordHighlightDecorator.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { ConfigurationManager } from "../configuration/ConfigurationManager";
 import { ScopedILogger } from "../telemetry/ILogger";
 import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
+import { getEditor } from "../utils/getEditor";
 import { throwIfCancellation } from "../utils/throwIfCancellation";
 
 /**
@@ -172,7 +173,7 @@ export class KeywordHighlightDecorator implements vscode.Disposable {
      * @param keyword The keyword to remove.
      */
     private removeKeywordHighlight(keyword: string) {
-        const editor = vscode.window.activeTextEditor;
+        const editor = getEditor();
         if (!editor) {
             this.logger.logException("removeKeywordHighlight", new Error("No active text editor"), "No active text editor");
             return;
@@ -203,7 +204,7 @@ export class KeywordHighlightDecorator implements vscode.Disposable {
             return;
         }
 
-        const editor = vscode.window.activeTextEditor;
+        const editor = getEditor();
         if (!editor) {
             this.logger.logException("applyAllKeywordDecorations", new Error("No active text editor"), "No active text editor");
             return;
@@ -254,7 +255,7 @@ export class KeywordHighlightDecorator implements vscode.Disposable {
             keywordRegex: keyword.regex.source,
         });
 
-        const editor = vscode.window.activeTextEditor;
+        const editor = getEditor();
         if (!editor) {
             this.logger.logException("applyKeywordDecoration", new Error("No active text editor"), "No active text editor");
             return;

--- a/src/extension/src/textDecorations/TextDecorator.ts
+++ b/src/extension/src/textDecorations/TextDecorator.ts
@@ -8,6 +8,7 @@ import * as vscode from "vscode";
 import { ERROR_REGEX, WARN_REGEX, WEB_DATE_REGEX_GLOBAL } from "../constants/regex";
 import { ScopedILogger } from "../telemetry/ILogger";
 import { ITelemetryLogger } from "../telemetry/ITelemetryLogger";
+import { getEditor } from "../utils/getEditor";
 import { throwIfCancellation } from "../utils/throwIfCancellation";
 
 /**
@@ -137,7 +138,7 @@ export class TextDecorator implements vscode.Disposable {
      * Removes the highlighting of the severity level in the logs viewer.
      */
     private removeSeverityLevelHighlighting() {
-        const editor = vscode.window.activeTextEditor;
+        const editor = getEditor();
         if (editor) {
             editor.setDecorations(this.errorTextDecoration, []);
             editor.setDecorations(this.warnTextDecoration, []);
@@ -147,10 +148,7 @@ export class TextDecorator implements vscode.Disposable {
             this.logger.logException(
                 "removeSeverityLevelHighlighting",
                 new Error("No active text editor"),
-                "No active text editor",
-                undefined,
-                true,
-                "Severity level highlighting"
+                "No active text editor"
             );
         }
     }
@@ -171,7 +169,7 @@ export class TextDecorator implements vscode.Disposable {
             currentState: "" + this.isSeverityLevelHighlightingEnabled,
         });
         if (this.isSeverityLevelHighlightingEnabled || wasTurnedOn) {
-            const editor = vscode.window.activeTextEditor;
+            const editor = getEditor();
             if (editor) {
                 const text = editor.document.getText();
                 this.logger.info("applySeverityLevelHighlighting.apply.start", undefined, { documentLength: "" + text.length });
@@ -257,10 +255,7 @@ export class TextDecorator implements vscode.Disposable {
                 this.logger.logException(
                     "applySeverityLevelHighlighting",
                     new Error("No active text editor"),
-                    "No active text editor",
-                    undefined,
-                    true,
-                    "Severity level highlighting"
+                    "No active text editor"
                 );
             }
         } else {
@@ -285,7 +280,7 @@ export class TextDecorator implements vscode.Disposable {
      * Removes the addition of human-readable dates in the logs viewer.
      */
     private removeReadableIsoDates() {
-        const editor = vscode.window.activeTextEditor;
+        const editor = getEditor();
         if (editor) {
             editor.setDecorations(this.isoDateTextDecoration, []);
             this.isReadableIsoDatesEnabled = false;
@@ -302,7 +297,7 @@ export class TextDecorator implements vscode.Disposable {
             currentState: "" + this.isReadableIsoDatesEnabled,
         });
         if (this.isReadableIsoDatesEnabled || wasTurnedOn) {
-            const editor = vscode.window.activeTextEditor;
+            const editor = getEditor();
             if (editor) {
                 const text = editor.document.getText();
                 const decorationsArray: vscode.DecorationOptions[] = [];
@@ -336,10 +331,7 @@ export class TextDecorator implements vscode.Disposable {
                 this.logger.logException(
                     "applyReadableIsoDates",
                     new Error("No active text editor"),
-                    "No active text editor",
-                    undefined,
-                    true,
-                    "Readable ISO dates"
+                    "No active text editor"
                 );
             }
         } else {

--- a/src/extension/src/utils/getEditor.ts
+++ b/src/extension/src/utils/getEditor.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+import * as vscode from "vscode";
+
+import { LogContentProvider } from "../providers/LogContentProvider";
+
+/**
+ * Gets the log content provider's visible text editor.
+ * @returns The log content provider's visible text editor.
+ */
+export const getEditor = () => {
+    return vscode.window.visibleTextEditors.find(e => e.document.uri.path === LogContentProvider.documentUri.path);
+};

--- a/src/ui/src/panels/filtering/KeywordFilter.tsx
+++ b/src/ui/src/panels/filtering/KeywordFilter.tsx
@@ -40,6 +40,7 @@ export const KeywordFilter: React.FC = () => {
     const [keywords, setKeywords] = React.useState<KeywordDefinition[]>(predefinedKeywords);
     const [newKeywordField, setNewKeywordField] = React.useState("");
     const { send, isPending } = useSendAndReceive("filterCheckboxStateChange", "updateNumberOfActiveFilters");
+    const { send: sendConfigUpdate } = useSendAndReceive("updateFilterCheckboxState", "messageAck");
     const keywordsFromConfiguration = useMessageSubscription("setKeywordFiltersFromConfiguration");
 
     React.useEffect(() => {
@@ -101,7 +102,8 @@ export const KeywordFilter: React.FC = () => {
 
         log("onAddKeyword", `Sending keyword '${newKeywordField}' to the extension backend`);
         send({ id: newKeyword.id, isChecked: true, value: newKeyword.keyword });
-    }, [newKeywordField, setKeywords, log, send]);
+        sendConfigUpdate({ id: newKeyword.id, isChecked: true, value: newKeyword.keyword, updateType: "add" });
+    }, [newKeywordField, setKeywords, log, send, sendConfigUpdate]);
 
     const onTextFieldKeyDown = React.useCallback(
         (event: React.KeyboardEvent<HTMLElement>) => {
@@ -120,8 +122,9 @@ export const KeywordFilter: React.FC = () => {
                 log("onRemoveKeyword", `Removing keyword enabled '${keyword.keyword}' with id: ${keyword.id}`);
                 send({ id: keyword.id, isChecked: false, value: keyword.keyword });
             }
+            sendConfigUpdate({ id: keyword.id, isChecked: false, value: keyword.keyword, updateType: "remove" });
         },
-        [setKeywords, log, send]
+        [setKeywords, log, send, sendConfigUpdate]
     );
 
     return (
@@ -170,5 +173,6 @@ export const KeywordFilter: React.FC = () => {
         </Flex>
     );
 };
+
 
 

--- a/src/ui/src/panels/filtering/KeywordFilter.tsx
+++ b/src/ui/src/panels/filtering/KeywordFilter.tsx
@@ -51,7 +51,7 @@ export const KeywordFilter: React.FC = () => {
                         keyword: kw.value,
                         isCustom: false,
                         id: uuid(),
-                        isChecked: false,
+                        isChecked: kw.isChecked,
                     };
                 });
                 return [...prev, ...newKeywords];
@@ -76,13 +76,14 @@ export const KeywordFilter: React.FC = () => {
                         `Sending keyword '${keyword.keyword}' with id: ${keywordId} and value: ${value} to the extension backend`
                     );
                     send({ id: keywordId, isChecked: value, value: keyword.keyword });
+                    sendConfigUpdate({ id: keywordId, isChecked: value, value: keyword.keyword, updateType: "update" });
                 } else {
                     logError("onCheckboxChange", `Could not find keyword with id '${keywordId}' and name '${name}'`);
                 }
                 return [...prev];
             });
         },
-        [log, logError, send]
+        [log, logError, send, sendConfigUpdate]
     );
 
     const onTextFieldChange = React.useCallback((event: Event | React.FormEvent<HTMLElement>) => {
@@ -173,6 +174,9 @@ export const KeywordFilter: React.FC = () => {
         </Flex>
     );
 };
+
+
+
 
 
 

--- a/src/ui/src/panels/filtering/LogLevelFilter.tsx
+++ b/src/ui/src/panels/filtering/LogLevelFilter.tsx
@@ -6,6 +6,7 @@ import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
 
 import { Flex } from "../../common/Flex";
+import { useMessageSubscription } from "../../service/useMessageSubscription";
 import { useSendAndReceive } from "../../service/useSendAndReceive";
 
 export const LogLevelFilter: React.FC = () => {
@@ -14,6 +15,30 @@ export const LogLevelFilter: React.FC = () => {
     const [infoFilterEnabled, setInfoFilterEnabled] = React.useState(true);
     const [debugFilterEnabled, setDebugFilterEnabled] = React.useState(true);
     const { send } = useSendAndReceive("filterLogLevel", "updateNumberOfActiveFilters");
+    const disabledConfigurationLogLevels = useMessageSubscription("setLogLevelFromConfiguration");
+
+    React.useEffect(() => {
+        if (disabledConfigurationLogLevels) {
+            for (const logLevel of disabledConfigurationLogLevels) {
+                switch (logLevel) {
+                    case "error":
+                        setErrorFilterEnabled(false);
+                        break;
+                    case "warning":
+                        setWarningFilterEnabled(false);
+                        break;
+                    case "info":
+                        setInfoFilterEnabled(false);
+                        break;
+                    case "debug":
+                        setDebugFilterEnabled(false);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }, [disabledConfigurationLogLevels]);
 
     const onCheckboxChange = React.useCallback(
         (event: Event | React.FormEvent<HTMLElement>) => {

--- a/src/ui/src/panels/highlighting/KeywordHighlightView.tsx
+++ b/src/ui/src/panels/highlighting/KeywordHighlightView.tsx
@@ -82,13 +82,14 @@ export const KeywordHighlightView: React.FC = () => {
                         `Sending highlight '${keyword.keyword}' with id: ${keywordId} and value: ${value} to the extension backend`
                     );
                     send({ isChecked: value, keywordDefinition: keyword });
+                    sendConfigUpdate({ keywordDefinition: keyword, updateType: "update" });
                 } else {
                     logError("onCheckboxChange", `Could not find highlight with id '${keywordId}' and name '${name}'`);
                 }
                 return [...prev];
             });
         },
-        [log, logError, send]
+        [log, logError, send, sendConfigUpdate]
     );
 
     const onAddKeyword = React.useCallback(
@@ -197,11 +198,4 @@ export const KeywordHighlightView: React.FC = () => {
         </>
     );
 };
-
-
-
-
-
-
-
 

--- a/src/ui/src/panels/highlighting/KeywordHighlightView.tsx
+++ b/src/ui/src/panels/highlighting/KeywordHighlightView.tsx
@@ -46,6 +46,7 @@ export const KeywordHighlightView: React.FC = () => {
     const [keywords, setKeywords] = React.useState<KeywordHighlightDefinition[]>([]);
 
     const { send, isPending } = useSendAndReceive("keywordHighlightStateChange", "messageAck", 4000);
+    const { send: sendConfigUpdate } = useSendAndReceive("updateKeywordHighlightConfiguration", "messageAck");
     const activeKeywords = useMessageSubscription("updateNumberOfHighlightedKeywords");
     const keywordsFromConfiguration = useMessageSubscription("setKeywordHighlightsFromConfiguration");
 
@@ -107,8 +108,9 @@ export const KeywordHighlightView: React.FC = () => {
 
             log("onAddKeyword", `Sending highlight '${keyword}' to the extension backend`);
             send({ isChecked: true, keywordDefinition: newKeyword });
+            sendConfigUpdate({ keywordDefinition: newKeyword, updateType: "add" });
         },
-        [setKeywords, log, send]
+        [setKeywords, log, send, sendConfigUpdate]
     );
 
     const onRemoveKeyword = React.useCallback(
@@ -119,8 +121,9 @@ export const KeywordHighlightView: React.FC = () => {
                 log("onRemoveKeyword", `Removing highlight enabled '${keyword.keyword}' with id: ${keyword.id}`);
                 send({ isChecked: false, keywordDefinition: keyword });
             }
+            sendConfigUpdate({ keywordDefinition: keyword, updateType: "remove" });
         },
-        [setKeywords, log, send]
+        [setKeywords, log, sendConfigUpdate, send]
     );
 
     const getOnKeywordColorChange = React.useCallback(
@@ -138,12 +141,13 @@ export const KeywordHighlightView: React.FC = () => {
                             send({ isChecked: false, keywordDefinition: kw });
                             send({ isChecked: true, keywordDefinition: kw });
                         }
+                        sendConfigUpdate({ keywordDefinition: kw, updateType: "update" });
                     }
                     return [...prev];
                 });
             };
         },
-        [setKeywords, log, send]
+        [setKeywords, log, send, sendConfigUpdate]
     );
 
     return (
@@ -193,6 +197,8 @@ export const KeywordHighlightView: React.FC = () => {
         </>
     );
 };
+
+
 
 
 


### PR DESCRIPTION
## Describe Your Changes

- Stores the current state of a debugging session in the logs folder so that it can be picked up later (or by somebody else)
- Persists following data:
  - cursor position (will jump back to last known position
  - disabled log levels
  - enabled keyword filters
  - enabled time filters
  - keyword highlights 

Example state:

```json
{
    "version": "1.0.1",
    "cursorPosition": 4371,
    "disabledLogLevels": [
        "debug"
    ],
    "enabledKeywordFilters": [
        "(a|A)uth"
    ],
    "enabledTimeFilters": {
        "fromDate": "1970-01-01T00:00:01.000Z",
        "tillDate": ""
    },
    "enabledKeywordHighlights": [
        {
            "keyword": "OneAuth",
            "color": "#e0c415"
        }
    ]
}
```

## Fixes Issues

- Closes #23 

## Self Checklist

- [X] Made sure that PR title has correct prefix (e.g. chore:, fix:, feat:, etc.)
- [X] The code is rebased on the latest main branch
- [X] Readme change log is clean
- [X] Commit messages are descriptive and contain the correct prefix
