### PR TITLE
Fix: Use correct regex for codicon font path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Automated build and release of the extension
 
 - improve release process
 
-
 ### 0.1.19
 
 #### 🚀 Features
@@ -96,8 +95,6 @@ Automated build and release of the extension
 #### 🧪 Maintenance
 
 - no matching changes
-
-
 
 #### 📦 Uncategorized
 
@@ -119,111 +116,23 @@ Automated build and release of the extension
 - fix: supply branch name to gitversion
 - BUMP version to 0.1.19
 
-
 ### 0.2.0
 
+#### 🚀 Features
 
-
-#### 📦 Uncategorized
-
-- Merge pull request #38 from felixSchober/fixes/fix-keyword-ack-messages
-- fix regeneration of severity highlighting
-- fix: update PR template
-- fix: cleanup readme
-- BUMP version to 0.1.18
-- bump gittools version
-- BUMP version to 0.1.18
-- fix GitVersion to use the right bumping logic
-- BUMP version to 0.1.18
-- checkout head.ref in bump version workflow job
-- BUMP version to 0.1.18
-- fix: supply branch name to gitversion
-- BUMP version to 0.1.19
-
-
-### 0.2.0
-
-
-
-#### 📦 Uncategorized
-
-- Merge pull request #38 from felixSchober/fixes/fix-keyword-ack-messages
-- fix regeneration of severity highlighting
-- fix: update PR template
-- fix: cleanup readme
-- BUMP version to 0.1.18
-- bump gittools version
-- BUMP version to 0.1.18
-- fix GitVersion to use the right bumping logic
-- BUMP version to 0.1.18
-- checkout head.ref in bump version workflow job
-- BUMP version to 0.1.18
-- fix: supply branch name to gitversion
-- BUMP version to 0.1.19
-
+- Stores the current state of a debugging session in the logs folder so that it can be picked up later (or by somebody else)
+- Persists following data:
+  - cursor position (will jump back to last known position)
+  - disabled log levels
+  - enabled keyword filters
+  - enabled time filters
+  - keyword highlights
 
 ### 0.2.1
 
+#### 🧪 Maintenance
 
-
-#### 📦 Uncategorized
-
-- Merge pull request #38 from felixSchober/fixes/fix-keyword-ack-messages
-- fix regeneration of severity highlighting
-- fix: update PR template
-- fix: cleanup readme
 - bump gittools version
-- fix GitVersion to use the right bumping logic
-- checkout head.ref in bump version workflow job
-- fix: supply branch name to gitversion
-- BUMP version to 0.1.19
-- Merge pull request #42 from felixSchober/fixes/reapply-severity-highlight
-- feat: improve release process
-- feat: add worklfow that creates a new release branch
-- BUMP version to 0.1.19
-- fix: run version bump after build
-- fix: remove origin target
-- BUMP version to 0.1.19
-- fix: print change log and make sure we always post a comment
-- update release configuration template
-- try new pre alpha
-- remove bloat and add uncategorized
-- BUMP version to 0.1.19
-- fix: removes bump message from PR changelog comment
-- fix: use right headings & cleanup readme
-- BUMP version to 0.1.19
-- Merge pull request #45 from felixSchober/fixes/how-to-release
-- Bump the eslint group with 3 updates
-- BUMP version to 0.1.19
-- fix: use personal PAT to create release branch
-- Merge pull request #46 from felixSchober/dependabot/npm_and_yarn/eslint-32f668daad
-- fix: Use onInput instead of onChange
-- chore: add more workspace extension reccomendations
-- fix: turn off no-unused-vars rule and replace by @typescript-eslint/no-unused-vars
-- feat: add color picker to keyword highlight page
-- feat: add griffel package to ui
-- chore: move color picker component to own folder
-- fix: downgrade griffel eslint to 1.5.1
-- fix: format webpack config
-- feat: improve createRandomColor to not create dark colors
-- feat: support class names in Flex component
-- feat: improve color picker styling
-- fix: Readme cleanup
-- fix: use public registry
-- fix: include from tag for changelog
-- BUMP version to 0.2.0
-- feat: Add color picker
-- feat: update keyword and filter highlight in configuration for extension
-- chore: move post message service to /service
-- fix: Create abstract helper base that disposes post message listeners
-- fix: Add getEditor which only returns the correct editor instead of just the active editor
-- feat: send update when checkbox state is changed
-- feat: add document location manager to store cursor positon
-- feat: store editor state in config file
-- fix: make sure tags are force pushed
-- ignore: remove debugger statement
-- BUMP version to 0.2.0
-
 
 ### #{NEW_VERSION}#
 

--- a/src/extension/media/sidePanelReact/assets/codicon.css
+++ b/src/extension/media/sidePanelReact/assets/codicon.css
@@ -14,7 +14,7 @@
  @font-face {
     font-family: "codicon";
     font-display: block;
-    src: url("https://file%2B.vscode-resource.vscode-cdn.net/Users/felix/Documents/Repositories/learning/t200Logs.nosync/media/sidePanelReact/codicon.ttf") format("truetype");
+    src: url("https://file%2B.vscode-resource.vscode-cdn.net/Users/felix/Documents/Repositories/learning/t200Logs.nosync/src/extension/media/sidePanelReact/assets/codicon.ttf") format("truetype");
   }
   
   .codicon[class*="codicon-"] {

--- a/src/extension/src/providers/WebviewPanelProvider.ts
+++ b/src/extension/src/providers/WebviewPanelProvider.ts
@@ -112,10 +112,7 @@ export class WebviewPanelProvider implements WebviewViewProvider {
 
         // replace the font path in the codiconCssPath CSS file with the webview URI
         let cssContent = fs.readFileSync(codiconCssPath.fsPath, "utf8");
-        cssContent = cssContent.replace(
-            /src:\s*url\(["'](\.\/codicon\.ttf\?[a-zA-Z0-9]+)["']\)\s*format\(["']truetype["']\);/,
-            codiconFontPath.toString()
-        );
+        cssContent = this.replaceCodiconFontPath(cssContent, codiconFontPath.toString());
         fs.writeFileSync(codiconCssPath.fsPath, cssContent);
 
         // Path to the JS file
@@ -132,6 +129,27 @@ export class WebviewPanelProvider implements WebviewViewProvider {
         this.logger.info("getHtmlForWebview.end", undefined, { htmlContentLength: "" + htmlContent.length });
 
         return htmlContent;
+    }
+
+    /**
+     * Replaces the font path in the CSS content with the webview URI.
+     * @param cssContent The CSS content of the codicon.css file.
+     * @param codiconFontPath The webview URI to the codicon.ttf file.
+     * @returns The CSS content with the font path replaced with the webview URI.
+     */
+    private replaceCodiconFontPath(cssContent: string, codiconFontPath: string): string {
+        // The following regex is used to replace the font path in the CSS content with the webview URI.
+        // It matches the following pattern:
+        // src: url("URL_TO_CODICON/codicon.ttf")
+        // There are three capturing groups:
+        // 1. src: url("
+        // 2. URL_TO_CODICON/codicon.ttf
+        // 3. ")
+        // These are then used to replace only the middle capturing group ($2) with the webview URI.
+        // eslint-disable-next-line no-useless-escape
+        const replacementRegex = /(src:\s*url\(\")(.*codicon.ttf)(\"\))/;
+
+        return cssContent.replace(replacementRegex, `$1${codiconFontPath}$3`);
     }
 }
 

--- a/src/extension/webpack.config.js
+++ b/src/extension/webpack.config.js
@@ -5,12 +5,10 @@
 "use strict";
 
 const path = require("path");
-const CopyPlugin = require("copy-webpack-plugin");
-const WatchExternalFilesPlugin = require('webpack-watch-files-plugin').default;
-//@ts-check
-/** @typedef {import('webpack').Configuration} WebpackConfig **/
 
-/** @type WebpackConfig */
+const CopyPlugin = require("copy-webpack-plugin");
+const WatchExternalFilesPlugin = require("webpack-watch-files-plugin").default;
+
 
 module.exports = (env) => {
     console.log("T200 EXTENSION", env);
@@ -21,6 +19,11 @@ module.exports = (env) => {
 
     const mediaPath = path.resolve(__dirname, "media", "sidePanelReact");
     console.log("T200 EXTENSION mediaPath", mediaPath);
+
+    const isProduction = env.production === true;
+    const sourceMaps = isProduction ? undefined : "inline-source-map";
+
+
     return {
         plugins: [
             new CopyPlugin({
@@ -69,7 +72,7 @@ module.exports = (env) => {
                 }
             ]
         },
-        devtool: "nosources-source-map",
+        devtool: sourceMaps,
         infrastructureLogging: {
             level: "log", // enables logging required for problem matchers
         },

--- a/src/ui/webpack.config.js
+++ b/src/ui/webpack.config.js
@@ -10,6 +10,8 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 module.exports = (env) => {
     console.log("T200 UI", env);
     console.log("T200 UI cwd", __dirname);
+    const isProduction = env.production === true;
+    const sourceMaps = isProduction ? undefined : "inline-source-map";
     const plugins = [
         new HtmlWebpackPlugin({
             template: path.join(__dirname, "src", "index.html"),
@@ -106,6 +108,7 @@ module.exports = (env) => {
                     type: "asset/resource"
                 }
             ]
-        }
+        },
+        devtool: sourceMaps
     };
 };


### PR DESCRIPTION
## Describe Your Changes

- Fixes codicon icons
- Fixes inline source maps for local builds and turns off source maps for prod builds

## Fixes Issues

- Closes #53 

## Self Checklist

- [X] Made sure that PR title has correct prefix (e.g. chore:, fix:, feat:, etc.)
- [X] The code is rebased on the latest main branch
- [X] Readme change log is clean
- [X] Commit messages are descriptive and contain the correct prefix
