### PR TITLE
fix: set git config name when pushing tag during ci run

### DIFF
--- a/.github/pr_configuration_template.json
+++ b/.github/pr_configuration_template.json
@@ -31,6 +31,7 @@
         }
     ],
     "ignore_labels": [
+        "ignore",
         "Merge",
         "BUMP"
     ],
@@ -41,7 +42,7 @@
     ],
     "label_extractor": [
         {
-            "pattern": "^(Merge|build|Bump|bump|BUMP|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}[:]?\\s(.*)",
+            "pattern": "^(ignore|Merge|build|Bump|bump|BUMP|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}[:]?\\s(.*)",
             "target": "$1"
         }
     ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
 
 permissions:
   contents: write
-  
+env:
+  BUMP_AUTHOR_MAIL: "t1000@felix-schober.de"
+  BUMP_AUTHOR_NAME: "T1000 BOT"
 jobs:
   build_changelog:
     name: CI/CD - Build changelog
@@ -132,6 +134,8 @@ jobs:
 
       - name: Create new release tag
         run: |
+          git config --local user.email ${{env.BUMP_AUTHOR_MAIL}}
+          git config --local user.name ${{env.BUMP_AUTHOR_NAME}}
           git tag -a ${{steps.get_latest_tag.outputs.tag}}-release -f -m "Release ${{steps.get_latest_tag.outputs.tag}}"
           git push origin -f --tags
 

--- a/README.md
+++ b/README.md
@@ -283,69 +283,13 @@ Automated build and release of the extension
 #### 🚀 Features
 
 - feat: improve release process
-- feat: add worklfow that creates a new release branch
-- feat: add color picker to keyword highlight page
-- feat: add griffel package to ui
-- feat: improve createRandomColor to not create dark colors
-- feat: support class names in Flex component
-- feat: improve color picker styling
-- feat: update keyword and filter highlight in configuration for extension
-- feat: send update when checkbox state is changed
-- feat: add document location manager to store cursor positon
-- feat: store editor state in config file
+- feat: add workflow that creates a new release branch
 
 #### 🐛 Bug Fixes
 
-- fix: move tags by force pushing
-- fix: update PR template
-- fix: cleanup readme
-- fix GitVersion to use the right bumping logic
-- fix: supply branch name to gitversion
-- fix: run version bump after build
-- fix: remove origin target
-- fix: print change log and make sure we always post a comment
-- fix: removes bump message from PR changelog comment
-- fix: use right headings & cleanup readme
-- fix: format webpack config
-- fix: Readme cleanup
-- fix: use public registry
-- fix: include from tag for changelog
-- fix: Create abstract helper base that disposes post message listeners
-- fix: Add getEditor which only returns the correct editor instead of just the active editor
-- fix: make sure tags are force pushed
 - fix: add inline source maps for local builds. Removes source maps for prod builds
 - fix: use correct regex to replace codicon font path with correct vscode path
 - fix: update readme
-
-#### 🧪 Maintenance
-
-- chore: add more workspace extension reccomendations
-- chore: move color picker component to own folder
-- chore: move post message service to /service
-
-
-#### 📦 Changes
-- specify the commit author name in the ci/cd workflow
-- use release job
-- Merge pull request #38 from felixSchober/fixes/fix-keyword-ack-messages
-- fix regeneration of severity highlighting
-- checkout head.ref in bump version workflow job
-- Merge pull request #42 from felixSchober/fixes/reapply-severity-highlight
-- update release configuration template
-- try new pre alpha
-- remove bloat and add uncategorized
-- Merge pull request #45 from felixSchober/fixes/how-to-release
-- Bump the eslint group with 3 updates
-- fix: use personal PAT to create release branch
-- Merge pull request #46 from felixSchober/dependabot/npm_and_yarn/eslint-32f668daad
-- fix: Use onInput instead of onChange
-- fix: turn off no-unused-vars rule and replace by @typescript-eslint/no-unused-vars
-- fix: downgrade griffel eslint to 1.5.1
-- feat: Add color picker
-- ignore: remove debugger statement
-- feat: Persist the log debugging state between logging sessions
-- build(deps): bump gittools/actions from 0.13.2 to 1.1.1
-- bump gittools/actions from 0.13.2 to 1.1.1
 
 
 ### #{NEW_VERSION}#


### PR DESCRIPTION
## Describe Your Changes

- set git config name when pushing tag during ci run

## Self Checklist

- [X] Made sure that PR title has correct prefix (e.g. chore:, fix:, feat:, etc.)
- [X] The code is rebased on the latest main branch
- [X] Readme change log is clean
- [X] Commit messages are descriptive and contain the correct prefix
